### PR TITLE
Could fr.jcgay.maven.plugins:buildplan-maven-plugin:1.6-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,11 +55,27 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>3.0.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-component-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>3.0.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.sonatype.plexus</groupId>
+                    <artifactId>plexus-sec-dispatcher</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-component-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
@@ -70,6 +86,12 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>11.0.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Hi! I found the pom file of project **_fr.jcgay.maven.plugins:buildplan-maven-plugin:1.6-SNAPSHOT_** introduced **_30_** dependencies. However, among them, **_4_** libraries (**_13%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:compile
org.sonatype.plexus:plexus-sec-dispatcher:jar:1.3:compile
org.sonatype.plexus:plexus-cipher:jar:1.4:compile
com.google.code.findbugs:jsr305:jar:1.3.9:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:compile_** induced dependency conflict in the dependency graph. As such, I suggest a refactoring operation for **_fr.jcgay.maven.plugins:buildplan-maven-plugin:1.6-SNAPSHOT_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_fr.jcgay.maven.plugins:buildplan-maven-plugin:1.6-SNAPSHOT_**’s maven tests.

Best regards
![image](https://user-images.githubusercontent.com/78527112/162885693-11c95c49-4992-4256-9fdc-285f65d4528c.png)
