### PR TITLE
Set goal prefix to 'bp'

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,24 +9,24 @@ A Maven 3.x plugin to inspect the lifecycle of your project. [Documentation](htt
 
 ### List plugin executions within a project
 
-	mvn buildplan:list
+	mvn bp:list
 
 ### List plugin executions within phases
 
-	mvn buildplan:list-phase
+	mvn bp:list-phase
 
 It is possible to limit the list to a specific phase:
 
-	mvn buildplan:list-phase -Dbuildplan.phase=test
+	mvn bp:list-phase -Dbp.phase=test
 
 ### List plugin executions by plugins
 
-	mvn buildplan:list-plugin
+	mvn bp:list-plugin
 
 It is possible to limit the list to a specific plugin:
 
-	mvn buildplan:list-plugin -Dbuildplan.plugin=maven-compiler-plugin
+	mvn bp:list-plugin -Dbp.plugin=maven-compiler-plugin
 
 ### List to output file
 
-	mvn buildplan:list -Dbuildplan.outputFile=buildplan_output.txt
+	mvn bp:list -Dbp.outputFile=buildplan_output.txt

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                    <goalPrefix>bp</goalPrefix>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/it/list-multimodule-cli-task/pom.xml
+++ b/src/it/list-multimodule-cli-task/pom.xml
@@ -10,7 +10,7 @@
   <packaging>pom</packaging>
 
   <description>
-    Test buildplan:list on multimodule project
+    Test bp:list on multimodule project
   </description>
 
   <modules>

--- a/src/it/list-multimodule-cli-task/test.properties
+++ b/src/it/list-multimodule-cli-task/test.properties
@@ -1,3 +1,3 @@
-buildplan.tasks = clean,versions:set,install
-buildplan.showLifecycles = true
+bp.tasks = clean,versions:set,install
+bp.showLifecycles = true
 expression = project.artifactId

--- a/src/it/list-multimodule-outputfile/invoker.properties
+++ b/src/it/list-multimodule-outputfile/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:list -Dbuildplan.outputFile=list.txt
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:list -Dbp.outputFile=list.txt

--- a/src/it/list-multimodule-outputfile/pom.xml
+++ b/src/it/list-multimodule-outputfile/pom.xml
@@ -10,7 +10,7 @@
   <packaging>pom</packaging>
 
   <description>
-    Test buildplan:list on multimodule project with output file
+    Test bp:list on multimodule project with output file
   </description>
 
   <modules>

--- a/src/it/list-multimodule-single-outputfile/invoker.properties
+++ b/src/it/list-multimodule-single-outputfile/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:list -Dbuildplan.outputFile=${basedir}/target/it/list-multimodule-single-outputfile/list.txt -Dbuildplan.appendOutput=true
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:list -Dbp.outputFile=${basedir}/target/it/list-multimodule-single-outputfile/list.txt -Dbp.appendOutput=true

--- a/src/it/list-multimodule-single-outputfile/pom.xml
+++ b/src/it/list-multimodule-single-outputfile/pom.xml
@@ -10,7 +10,7 @@
   <packaging>pom</packaging>
 
   <description>
-    Test buildplan:list on multimodule project with a single output file
+    Test bp:list on multimodule project with a single output file
   </description>
 
   <modules>

--- a/src/it/list-multimodule-with-lifecycle/pom.xml
+++ b/src/it/list-multimodule-with-lifecycle/pom.xml
@@ -10,7 +10,7 @@
   <packaging>pom</packaging>
 
   <description>
-    Test buildplan:list on multimodule project
+    Test bp:list on multimodule project
   </description>
 
   <modules>

--- a/src/it/list-multimodule-with-lifecycle/test.properties
+++ b/src/it/list-multimodule-with-lifecycle/test.properties
@@ -1,2 +1,2 @@
-buildplan.tasks = clean,deploy
-buildplan.showLifecycles = true
+bp.tasks = clean,deploy
+bp.showLifecycles = true

--- a/src/it/list-multimodule/pom.xml
+++ b/src/it/list-multimodule/pom.xml
@@ -10,7 +10,7 @@
   <packaging>pom</packaging>
 
   <description>
-    Test buildplan:list on multimodule project
+    Test bp:list on multimodule project
   </description>
 
   <modules>

--- a/src/it/list-phase-cli-task/pom.xml
+++ b/src/it/list-phase-cli-task/pom.xml
@@ -9,7 +9,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <description>
-    Test buildplan:list-phase
+    Test bp:list-phase
   </description>
 
 </project>

--- a/src/it/list-phase-cli-task/test.properties
+++ b/src/it/list-phase-cli-task/test.properties
@@ -1,3 +1,3 @@
- buildplan.tasks = clean,versions:set,install
- buildplan.showAllPhases = true
- buildplan.showLifecycles = true
+ bp.tasks = clean,versions:set,install
+ bp.showAllPhases = true
+ bp.showLifecycles = true

--- a/src/it/list-phase-pom-skipped/pom.xml
+++ b/src/it/list-phase-pom-skipped/pom.xml
@@ -9,7 +9,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <description>
-    Test buildplan:list-phase
+    Test bp:list-phase
   </description>
 
   <build>

--- a/src/it/list-phase-pom/pom.xml
+++ b/src/it/list-phase-pom/pom.xml
@@ -9,7 +9,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <description>
-    Test buildplan:list-phase
+    Test bp:list-phase
   </description>
 
   <build>

--- a/src/it/list-phase-show-all-phases-with-lifecycle/pom.xml
+++ b/src/it/list-phase-show-all-phases-with-lifecycle/pom.xml
@@ -9,7 +9,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <description>
-    Test buildplan:list-phase
+    Test bp:list-phase
   </description>
 
 </project>

--- a/src/it/list-phase-show-all-phases-with-lifecycle/test.properties
+++ b/src/it/list-phase-show-all-phases-with-lifecycle/test.properties
@@ -1,3 +1,3 @@
- buildplan.tasks = clean,deploy
- buildplan.showAllPhases = true
- buildplan.showLifecycles = true
+ bp.tasks = clean,deploy
+ bp.showAllPhases = true
+ bp.showLifecycles = true

--- a/src/it/list-phase-show-all-phases/pom.xml
+++ b/src/it/list-phase-show-all-phases/pom.xml
@@ -9,7 +9,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <description>
-    Test buildplan:list-phase
+    Test bp:list-phase
   </description>
 
 </project>

--- a/src/it/list-phase-show-all-phases/test.properties
+++ b/src/it/list-phase-show-all-phases/test.properties
@@ -1,2 +1,2 @@
- buildplan.tasks = clean,deploy
- buildplan.showAllPhases = true
+ bp.tasks = clean,deploy
+ bp.showAllPhases = true

--- a/src/it/list-phase-skipped/invoker.properties
+++ b/src/it/list-phase-skipped/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:list-phase -Dbuildplan.skip=true
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:list-phase -Dbp.skip=true

--- a/src/it/list-phase-skipped/pom.xml
+++ b/src/it/list-phase-skipped/pom.xml
@@ -9,7 +9,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <description>
-    Test buildplan:list-phase
+    Test bp:list-phase
   </description>
 
 </project>

--- a/src/it/list-phase-with-lifecycle/pom.xml
+++ b/src/it/list-phase-with-lifecycle/pom.xml
@@ -9,7 +9,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <description>
-    Test buildplan:list-phase
+    Test bp:list-phase
   </description>
 
 </project>

--- a/src/it/list-phase-with-lifecycle/test.properties
+++ b/src/it/list-phase-with-lifecycle/test.properties
@@ -1,2 +1,2 @@
- buildplan.tasks = clean,deploy
- buildplan.showLifecycles = true
+ bp.tasks = clean,deploy
+ bp.showLifecycles = true

--- a/src/it/list-phase/pom.xml
+++ b/src/it/list-phase/pom.xml
@@ -9,7 +9,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <description>
-    Test buildplan:list-phase
+    Test bp:list-phase
   </description>
 
 </project>

--- a/src/it/list-plugin-skipped/invoker.properties
+++ b/src/it/list-plugin-skipped/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:list-plugin -Dbuildplan.skip=true
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:list-plugin -Dbp.skip=true

--- a/src/it/list-plugin-skipped/pom.xml
+++ b/src/it/list-plugin-skipped/pom.xml
@@ -9,7 +9,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <description>
-    Test buildplan:list-plugin
+    Test bp:list-plugin
   </description>
 
 </project>

--- a/src/it/list-plugin/pom.xml
+++ b/src/it/list-plugin/pom.xml
@@ -9,7 +9,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <description>
-    Test buildplan:list-plugin
+    Test bp:list-plugin
   </description>
 
 </project>

--- a/src/main/java/org/codehaus/mojo/buildplan/AbstractLifecycleMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildplan/AbstractLifecycleMojo.java
@@ -44,19 +44,19 @@ public abstract class AbstractLifecycleMojo extends AbstractMojo {
     private LifecycleExecutor lifecycleExecutor;
 
     /** Allow to specify which tasks will be used to calculate execution plan. */
-    @Parameter(property = "buildplan.tasks", defaultValue = "deploy")
+    @Parameter(property = "bp.tasks", defaultValue = "deploy")
     private String[] tasks;
 
     /** Allow to specify an output file to bypass console output */
-    @Parameter(property = "buildplan.outputFile")
+    @Parameter(property = "bp.outputFile")
     private File outputFile;
 
     /** Allow to specify appending to the output file */
-    @Parameter(property = "buildplan.appendOutput", defaultValue = "false")
+    @Parameter(property = "bp.appendOutput", defaultValue = "false")
     private boolean appendOutput;
 
     /** Flag to easily skip all checks  */
-    @Parameter(property = "buildplan.skip", defaultValue = "false")
+    @Parameter(property = "bp.skip", defaultValue = "false")
     private boolean skip = false;
 
     protected MavenExecutionPlan calculateExecutionPlan() throws MojoFailureException {

--- a/src/main/java/org/codehaus/mojo/buildplan/ListMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildplan/ListMojo.java
@@ -41,7 +41,7 @@ import org.codehaus.plexus.util.StringUtils;
       requiresProject = true)
 public class ListMojo extends AbstractLifecycleMojo {
 
-    @Parameter(property = "buildplan.showLifecycles", defaultValue = "false")
+    @Parameter(property = "bp.showLifecycles", defaultValue = "false")
     private boolean showLifecycles;
 
     public void executeInternal() throws MojoFailureException {

--- a/src/main/java/org/codehaus/mojo/buildplan/ListPhaseMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildplan/ListPhaseMojo.java
@@ -41,13 +41,13 @@ import org.codehaus.plexus.util.StringUtils;
 public class ListPhaseMojo extends AbstractLifecycleMojo {
 
     /** Display plugin executions only for the specified phase. */
-    @Parameter(property = "buildplan.phase")
+    @Parameter(property = "bp.phase")
     private String phase;
 
-    @Parameter(property = "buildplan.showLifecycles", defaultValue = "false")
+    @Parameter(property = "bp.showLifecycles", defaultValue = "false")
     private boolean showLifecycles;
 
-    @Parameter(property = "buildplan.showAllPhases", defaultValue = "false")
+    @Parameter(property = "bp.showAllPhases", defaultValue = "false")
     private boolean showAllPhases;
 
     public void executeInternal() throws MojoFailureException {

--- a/src/main/java/org/codehaus/mojo/buildplan/ListPluginMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildplan/ListPluginMojo.java
@@ -39,7 +39,7 @@ import org.codehaus.plexus.util.StringUtils;
 public class ListPluginMojo extends AbstractLifecycleMojo {
 
     /** Display plugin executions only for the specified plugin. */
-    @Parameter(property = "buildplan.plugin")
+    @Parameter(property = "bp.plugin")
     private String plugin;
 
     public void executeInternal() throws MojoFailureException {

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -6,9 +6,9 @@ A Maven 3.x plugin to inspect the lifecycle of your project.
 
 The BuildPlan plugin has three goals:
 
-* [buildplan:list](list-mojo.html) displays plugin executions within a Maven project.
-* [buildplan:list-phase](list-phase-mojo.html) displays plugin executions within lifecycle phases.
-* [buildplan:list-plugin](list-plugin-mojo.html) displays plugin executions by plugin.
+* [bp:list](list-mojo.html) displays plugin executions within a Maven project.
+* [bp:list-phase](list-phase-mojo.html) displays plugin executions within lifecycle phases.
+* [bp:list-plugin](list-plugin-mojo.html) displays plugin executions by plugin.
 
 ## Examples
 

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -2,7 +2,7 @@
 
 ## List plugin executions within a project
 ```
-> mvn buildplan:list
+> mvn bp:list
 
 [INFO] --- buildplan-maven-plugin:0.1-SNAPSHOT:list (default-cli) @ buildplan-maven-plugin ---
 [INFO] --------------------------------------------------------------------------------------------------------------------
@@ -26,15 +26,15 @@
 ```
 It is possible to define the tasks used to calculate execution plan:
 
-	mvn buildplan:list-phase -Dbuildplan.tasks=clean,test
+	mvn bp:list-phase -Dbp.tasks=clean,test
 
 If you want to show the lifecycle that defines the listed phase(s), add this parameter:
 
-	mvn buildplan:list-phase -Dbuildplan.showLifecycles
+	mvn bp:list-phase -Dbp.showLifecycles
 
 ## List plugin executions within phases
 ```
-> mvn buildplan:list-phase
+> mvn bp:list-phase
 
 [INFO] --- buildplan-maven-plugin:0.1-SNAPSHOT:list-phase (default-cli) @ buildplan-maven-plugin ---
 [INFO] install ------------------------------------------------------------------------------------------
@@ -66,22 +66,22 @@ If you want to show the lifecycle that defines the listed phase(s), add this par
 ```
 It is possible to limit the list to a specific phase:
 
-	mvn buildplan:list-phase -Dbuildplan.phase=test
+	mvn bp:list-phase -Dbp.phase=test
 
 If you want to include phases that have no executions mapped:
 
-	mvn buildplan:list-phase -Dbuildplan.showAllPhases
+	mvn bp:list-phase -Dbp.showAllPhases
 
 Here it is also possible to show the lifecycle(s) by running:
 
-	mvn buildplan:list-phase -Dbuildplan.showLifecycles
+	mvn bp:list-phase -Dbp.showLifecycles
 
-Be aware that setting `buildplan.tasks` to direct plugin-executions (eg 'release:prepare') will show an empty lifecycle and '&lt;no phase&gt;', since they are not mapped.
+Be aware that setting 'bp.tasks' to direct plugin-executions (eg 'release:prepare') will show an empty lifecycle and '&lt;no phase&gt;', since they are not mapped.
 Also, because executions are collected per phase, direct plugin-executions are shown in the list at the location of the very first execution.
 
 ## List plugin executions by plugins
 ```
-> mvn buildplan:list-plugin
+> mvn bp:list-plugin
 
 [INFO] --- buildplan-maven-plugin:0.1-SNAPSHOT:list-plugin (default-cli) @ buildplan-maven-plugin ---
 [INFO] maven-deploy-plugin -------------------------------------------------------------------------
@@ -112,8 +112,8 @@ Also, because executions are collected per phase, direct plugin-executions are s
 ```
 It is possible to limit the list to a specific plugin:
 
-	mvn buildplan:list-plugin -Dbuildplan.plugin=maven-compiler-plugin
+	mvn bp:list-plugin -Dbp.plugin=maven-compiler-plugin
 
 It is possible to redirect the output to a file:
 
-	mvn buildplan:list-plugin -Dbuildplan.outputFile=buildplan_output.txt
+	mvn bp:list-plugin -Dbp.outputFile=buildplan_output.txt


### PR DESCRIPTION
Following @hboutemy proposal to make the plugin CLI shorter.  
I don't remember seeing a plugin with a goal prefix not included in its artifactId but if this is legit why not 😇.

Instead of executing the plugin with:

    mvn buildplan:list

It will be available with:

    mvn bp:list