### PR TITLE
Remove Guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,11 +74,6 @@
             <artifactId>maven-plugin-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>11.0.2</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/codehaus/mojo/buildplan/Groups.java
+++ b/src/main/java/org/codehaus/mojo/buildplan/Groups.java
@@ -15,18 +15,17 @@
  */
 package org.codehaus.mojo.buildplan;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.Multimap;
-import org.apache.maven.lifecycle.DefaultLifecycles;
-import org.apache.maven.lifecycle.Lifecycle;
-import org.apache.maven.plugin.MojoExecution;
-import org.codehaus.plexus.logging.console.ConsoleLogger;
+import static org.codehaus.mojo.buildplan.util.Objects.firstNonNull;
+import static org.codehaus.plexus.util.StringUtils.isEmpty;
 
 import java.util.Collections;
 import java.util.List;
-
-import static com.google.common.base.Objects.firstNonNull;
+import org.apache.maven.lifecycle.DefaultLifecycles;
+import org.apache.maven.lifecycle.Lifecycle;
+import org.apache.maven.plugin.MojoExecution;
+import org.codehaus.mojo.buildplan.util.LinkedMultimap;
+import org.codehaus.mojo.buildplan.util.Multimap;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
 
 public class Groups {
 
@@ -37,8 +36,8 @@ public class Groups {
         }
 
         public static Multimap<String,MojoExecution> of(List<MojoExecution> executions, String artifactIdFilter) {
-            Multimap<String, MojoExecution> result = LinkedListMultimap.create();
-            boolean notFiltering = Strings.isNullOrEmpty(artifactIdFilter);
+            Multimap<String, MojoExecution> result = new LinkedMultimap<>();
+            boolean notFiltering = isEmpty(artifactIdFilter);
             for (MojoExecution execution : executions) {
                 if (notFiltering || execution.getArtifactId().equalsIgnoreCase(artifactIdFilter)) {
                     result.put(execution.getArtifactId(), execution);
@@ -59,8 +58,8 @@ public class Groups {
         }
 
         public static Multimap<String, MojoExecution> of(List<MojoExecution> executions, Options options) {
-            Multimap<String, MojoExecution> result = LinkedListMultimap.create();
-            boolean notFiltering = Strings.isNullOrEmpty(options.phase);
+            Multimap<String, MojoExecution> result = new LinkedMultimap<>();
+            boolean notFiltering = isEmpty(options.phase);
             for (MojoExecution execution : executions) {
                 String phase = firstNonNull(execution.getLifecyclePhase(), "<no phase>");
                 if (options.showingAllPhases) {

--- a/src/main/java/org/codehaus/mojo/buildplan/ListMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildplan/ListMojo.java
@@ -15,7 +15,6 @@
  */
 package org.codehaus.mojo.buildplan;
 
-import com.google.common.base.Strings;
 
 import static org.codehaus.mojo.buildplan.display.Output.lineSeparator;
 import static org.codehaus.mojo.buildplan.display.TableColumn.ARTIFACT_ID;
@@ -32,6 +31,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.mojo.buildplan.display.ListTableDescriptor;
 import org.codehaus.mojo.buildplan.display.MojoExecutionDisplay;
 import org.codehaus.mojo.buildplan.display.TableDescriptor;
+import org.codehaus.plexus.util.StringUtils;
 
 /**
  * List plugin executions for the current project.
@@ -99,6 +99,6 @@ public class ListMojo extends AbstractLifecycleMojo {
     }
 
     private String titleSeparator(TableDescriptor descriptor) {
-        return Strings.repeat("-", descriptor.width());
+        return StringUtils.repeat("-", descriptor.width());
     }
 }

--- a/src/main/java/org/codehaus/mojo/buildplan/ListPhaseMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildplan/ListPhaseMojo.java
@@ -15,9 +15,12 @@
  */
 package org.codehaus.mojo.buildplan;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.Multimap;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.codehaus.mojo.buildplan.display.Output.lineSeparator;
 
+import java.util.Collection;
+import java.util.Map;
 import org.apache.maven.lifecycle.Lifecycle;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoFailureException;
@@ -26,13 +29,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.mojo.buildplan.display.ListPhaseTableDescriptor;
 import org.codehaus.mojo.buildplan.display.MojoExecutionDisplay;
 import org.codehaus.mojo.buildplan.display.TableDescriptor;
-
-import java.util.Collection;
-import java.util.Map;
-
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
-import static org.codehaus.mojo.buildplan.display.Output.lineSeparator;
+import org.codehaus.mojo.buildplan.util.Multimap;
+import org.codehaus.plexus.util.StringUtils;
 
 /**
  * List plugin executions by phase for the current project.
@@ -100,6 +98,6 @@ public class ListPhaseMojo extends AbstractLifecycleMojo {
     }
 
     private String phaseTitleLine(TableDescriptor descriptor, String key) {
-        return key + " " + Strings.repeat("-", descriptor.width() - key.length());
+        return key + " " + StringUtils.repeat("-", descriptor.width() - key.length());
     }
 }

--- a/src/main/java/org/codehaus/mojo/buildplan/ListPluginMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildplan/ListPluginMojo.java
@@ -15,21 +15,20 @@
  */
 package org.codehaus.mojo.buildplan;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.Multimap;
-
-import org.apache.maven.plugin.MojoExecution;
-import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
-import org.codehaus.mojo.buildplan.display.ListPluginTableDescriptor;
-import org.codehaus.mojo.buildplan.display.MojoExecutionDisplay;
-import org.codehaus.mojo.buildplan.display.TableDescriptor;
-
 import static org.codehaus.mojo.buildplan.display.Output.lineSeparator;
 
 import java.util.Collection;
 import java.util.Map;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.codehaus.mojo.buildplan.Groups.ByPlugin;
+import org.codehaus.mojo.buildplan.display.ListPluginTableDescriptor;
+import org.codehaus.mojo.buildplan.display.MojoExecutionDisplay;
+import org.codehaus.mojo.buildplan.display.TableDescriptor;
+import org.codehaus.mojo.buildplan.util.Multimap;
+import org.codehaus.plexus.util.StringUtils;
 
 /**
  * List plugin executions by plugin for the current project.
@@ -74,6 +73,6 @@ public class ListPluginMojo extends AbstractLifecycleMojo {
     }
 
     private String pluginTitleLine(TableDescriptor descriptor, String key) {
-        return key + " " + Strings.repeat("-", descriptor.width() - key.length());
+        return key + " " + StringUtils.repeat("-", descriptor.width() - key.length());
     }
 }

--- a/src/main/java/org/codehaus/mojo/buildplan/display/AbstractTableDescriptor.java
+++ b/src/main/java/org/codehaus/mojo/buildplan/display/AbstractTableDescriptor.java
@@ -15,18 +15,18 @@
  */
 package org.codehaus.mojo.buildplan.display;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-import org.apache.maven.lifecycle.DefaultLifecycles;
-import org.apache.maven.lifecycle.Lifecycle;
-import org.apache.maven.plugin.MojoExecution;
-import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import static org.codehaus.plexus.util.StringUtils.defaultString;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.maven.lifecycle.DefaultLifecycles;
+import org.apache.maven.lifecycle.Lifecycle;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.codehaus.mojo.buildplan.util.LinkedMultimap;
+import org.codehaus.mojo.buildplan.util.Multimap;
 
 public abstract class AbstractTableDescriptor implements TableDescriptor {
 
@@ -34,7 +34,7 @@ public abstract class AbstractTableDescriptor implements TableDescriptor {
 
         Map<TableColumn, Integer> result = new HashMap<>();
 
-        Multimap<TableColumn, Integer> count = ArrayListMultimap.create();
+        Multimap<TableColumn, Integer> count = new LinkedMultimap<>();
         for (MojoExecution execution : executions) {
             for (TableColumn column : columns) {
                 switch (column) {
@@ -76,6 +76,6 @@ public abstract class AbstractTableDescriptor implements TableDescriptor {
     }
 
     private static int safeLength(String string) {
-        return Strings.nullToEmpty(string).length();
+        return defaultString(string).length();
     }
 }

--- a/src/main/java/org/codehaus/mojo/buildplan/display/ListTableDescriptor.java
+++ b/src/main/java/org/codehaus/mojo/buildplan/display/ListTableDescriptor.java
@@ -15,13 +15,11 @@
  */
 package org.codehaus.mojo.buildplan.display;
 
-import org.apache.maven.lifecycle.DefaultLifecycles;
-import org.apache.maven.plugin.MojoExecution;
-
 import java.util.Collection;
 import java.util.Map;
-
-import static com.google.common.base.Objects.toStringHelper;
+import java.util.StringJoiner;
+import org.apache.maven.lifecycle.DefaultLifecycles;
+import org.apache.maven.plugin.MojoExecution;
 
 public class ListTableDescriptor extends AbstractTableDescriptor {
 
@@ -66,13 +64,15 @@ public class ListTableDescriptor extends AbstractTableDescriptor {
 
     @Override
     public String toString() {
-        return toStringHelper(this).add("Plugin column size", getPluginSize())
-                                   .add("Phase column size", getPhaseSize())
-                                   .add("Lifecycle column size", getLifecycleSize())
-                                   .add("Execution ID column size", getExecutionIdSize())
-                                   .add("Goal column size", getGoalSize())
-                                   .add("width", width())
-                                   .toString();
+        return new StringJoiner(", ", ListTableDescriptor.class.getSimpleName() + "[", "]")
+            .add("Plugin column size=" + pluginSize)
+            .add("Phase column size=" + phaseSize)
+            .add("Lifecycle column size=" + lifecycleSize)
+            .add("Execution ID column size=" + executionIdSize)
+            .add("Goal column size=" + goalSize)
+            .add("width=" + width())
+            .toString();
+
     }
 
     public int getPluginSize() {

--- a/src/main/java/org/codehaus/mojo/buildplan/display/MojoExecutionDisplay.java
+++ b/src/main/java/org/codehaus/mojo/buildplan/display/MojoExecutionDisplay.java
@@ -15,11 +15,11 @@
  */
 package org.codehaus.mojo.buildplan.display;
 
+import static org.codehaus.plexus.util.StringUtils.defaultString;
+
 import org.apache.maven.lifecycle.DefaultLifecycles;
 import org.apache.maven.lifecycle.Lifecycle;
 import org.apache.maven.plugin.MojoExecution;
-
-import static com.google.common.base.Strings.nullToEmpty;
 
 public class MojoExecutionDisplay {
 
@@ -30,23 +30,23 @@ public class MojoExecutionDisplay {
     }
 
     public String getPhase() {
-        return nullToEmpty(execution.getLifecyclePhase());
+        return defaultString(execution.getLifecyclePhase());
     }
 
     public String getLifecycle(DefaultLifecycles defaultLifecycles) {
         Lifecycle lifecycle = defaultLifecycles.get(execution.getLifecyclePhase());
-        return nullToEmpty(lifecycle == null ? null : lifecycle.getId());
+        return defaultString(lifecycle == null ? null : lifecycle.getId());
     }
 
     public String getArtifactId() {
-        return nullToEmpty(execution.getArtifactId());
+        return defaultString(execution.getArtifactId());
     }
 
     public String getGoal() {
-        return nullToEmpty(execution.getGoal());
+        return defaultString(execution.getGoal());
     }
 
     public String getExecutionId() {
-        return nullToEmpty(execution.getExecutionId());
+        return defaultString(execution.getExecutionId());
     }
 }

--- a/src/main/java/org/codehaus/mojo/buildplan/util/LinkedMultimap.java
+++ b/src/main/java/org/codehaus/mojo/buildplan/util/LinkedMultimap.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2012 Jean-Christophe Gay (contact@jeanchristophegay.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.buildplan.util;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class LinkedMultimap<K, V> implements Multimap<K, V> {
+
+    private final Map<K, Collection<V>> map = new LinkedHashMap<>();
+
+    @Override
+    public Set<K> keySet() {
+        return map.keySet();
+    }
+
+    @Override
+    public Collection<V> get(K key) {
+        return map.get(key);
+    }
+
+    @Override
+    public boolean put(K key, V value) {
+        map.computeIfAbsent(key, k -> new ArrayList<>());
+        return map.get(key).add(value);
+    }
+
+    @Override
+    public Map<K, Collection<V>> asMap() {
+        return map;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override
+    public Collection<V> values() {
+        return map.values().stream()
+            .flatMap(Collection::stream)
+            .collect(toList());
+    }
+}

--- a/src/main/java/org/codehaus/mojo/buildplan/util/Multimap.java
+++ b/src/main/java/org/codehaus/mojo/buildplan/util/Multimap.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2012 Jean-Christophe Gay (contact@jeanchristophegay.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.buildplan.util;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+public interface Multimap<K, V> {
+
+    Set<K> keySet();
+
+    Collection<V> get(K key);
+
+    boolean put(K key, V value);
+
+    Map<K, Collection<V>> asMap();
+
+    boolean isEmpty();
+
+    Collection<V> values();
+}

--- a/src/main/java/org/codehaus/mojo/buildplan/util/Objects.java
+++ b/src/main/java/org/codehaus/mojo/buildplan/util/Objects.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2012 Jean-Christophe Gay (contact@jeanchristophegay.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.buildplan.util;
+
+public class Objects {
+
+    private Objects() {
+    }
+
+    public static <T> T firstNonNull(T first, T second) {
+        return first != null ? first : java.util.Objects.requireNonNull(second);
+    }
+}

--- a/src/test/java/org/codehaus/mojo/buildplan/GroupsTest.java
+++ b/src/test/java/org/codehaus/mojo/buildplan/GroupsTest.java
@@ -15,15 +15,16 @@
  */
 package org.codehaus.mojo.buildplan;
 
-import com.google.common.collect.Multimap;
-import org.apache.maven.plugin.MojoExecution;
-import org.junit.Test;
-
-import java.util.Map;
-
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.codehaus.mojo.buildplan.model.builder.MojoExecutionBuilder.aMojoExecution;
+
+import java.util.Map;
+import org.apache.maven.plugin.MojoExecution;
+import org.codehaus.mojo.buildplan.Groups.ByPhase;
+import org.codehaus.mojo.buildplan.Groups.ByPlugin;
+import org.codehaus.mojo.buildplan.util.Multimap;
+import org.junit.Test;
 
 public class GroupsTest {
 
@@ -51,7 +52,7 @@ public class GroupsTest {
                                                 .withLifecyclePhase("d-phase")
                                                 .build();
 
-        Multimap<String,MojoExecution> result = Groups.ByPhase.of(asList(pluginD, pluginA, pluginC, pluginB));
+        Multimap<String, MojoExecution> result = Groups.ByPhase.of(asList(pluginD, pluginA, pluginC, pluginB));
 
         assertThat(result.keySet()).containsOnly("phase", "a-phase", "d-phase");
         assertThat(result.get("phase")).containsOnly(pluginA, pluginB);


### PR DESCRIPTION
This is used by recentest Maven with android flavor. We don't really know when Guava will break things (even if they have changed their mind these years...).
There was no strong usage on it so we will be better without an additional dependency 😇.