### PR TITLE
Support fork repositories and dependabot branches build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,21 +19,23 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: ./mvnw --batch-mode verify
-    - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v2.0.0-beta.2
+    - name: Upload test results
+      uses: actions/upload-artifact@v2
       if: always()
       with:
-        files: |
-            target/surefire-reports/*.xml
+        name: Test Results
+        path: |
+            target/surefire-reports/TEST*.xml
             target/failsafe-reports/TEST*.xml
-    - name: Publish Code Coverage in PR
-      id: jacoco
-      uses: madrapps/jacoco-report@v1.2
-      with:
-        paths: ${{ github.workspace }}/target/site/jacoco/jacoco.xml
-        token: ${{ secrets.GITHUB_TOKEN }}
-        min-coverage-overall: 55
-        min-coverage-changed-files: 70
-      if: github.event_name == 'pull_request'
+            target/site/jacoco/jacoco.xml
     - name: Build documentation
       run: ./mvnw --batch-mode site
+  event_file:
+    name: "Publish event file"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: Event File
+          path: ${{ github.event_path }}

--- a/.github/workflows/tests-result-and-coverage.yml
+++ b/.github/workflows/tests-result-and-coverage.yml
@@ -1,0 +1,55 @@
+name: Reports
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+permissions: {}
+
+jobs:
+  test-results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    permissions:
+      checks: write
+      # needed unless run with comment_mode: off
+      pull-requests: write
+      # required by download step to access artifacts API
+      actions: read
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          mkdir -p artifacts && cd artifacts
+
+          artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+          gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+          do
+          IFS=$'\t' read name url <<< "$artifact"
+          gh api $url > "$name.zip"
+          unzip -d "$name" "$name.zip"
+          done
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          junit_files: "artifacts/**/TEST*.xml"
+
+      - name: Publish Code Coverage in PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.2
+        with:
+          paths: "artifacts/**/jacoco.xml"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 55
+          min-coverage-changed-files: 70
+          if: ${{ github.event.workflow_run.event }} == 'pull_request'


### PR DESCRIPTION
GitHub actions build was failing with:

    Publish Unit Test Results
	...
	raise GithubException(response.status, content, response.headers)
	github.GithubException.GithubException: 403 {"message": "Resource not accessible by integration", "documentation_url": "https://docs.github.com/rest/reference/checks#create-a-check-run"}

Follow https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches to respect permissions.

Fixes #134