### PR TITLE
Reorder columns order for list-plugin goal

### DIFF
--- a/src/main/java/org/codehaus/mojo/buildplan/ListPluginMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildplan/ListPluginMojo.java
@@ -66,8 +66,8 @@ public class ListPluginMojo extends AbstractLifecycleMojo {
         MojoExecutionDisplay display = new MojoExecutionDisplay(execution);
 
         return String.format(rowFormat, display.getPhase(),
-                                        display.getExecutionId(),
-                                        display.getGoal());
+                                        display.getGoal(),
+                                        display.getExecutionId());
     }
 
     private String pluginTitleLine(TableDescriptor descriptor, String key) {

--- a/src/main/java/org/codehaus/mojo/buildplan/display/ListPluginTableDescriptor.java
+++ b/src/main/java/org/codehaus/mojo/buildplan/display/ListPluginTableDescriptor.java
@@ -15,11 +15,10 @@
  */
 package org.codehaus.mojo.buildplan.display;
 
-import org.apache.maven.lifecycle.DefaultLifecycles;
-import org.apache.maven.plugin.MojoExecution;
-
 import java.util.Collection;
 import java.util.Map;
+import org.apache.maven.lifecycle.DefaultLifecycles;
+import org.apache.maven.plugin.MojoExecution;
 
 public class ListPluginTableDescriptor extends AbstractTableDescriptor {
 
@@ -34,9 +33,9 @@ public class ListPluginTableDescriptor extends AbstractTableDescriptor {
         builder.append(ROW_START)
                 .append(FORMAT_LEFT_ALIGN).append(getPhaseSize()).append(FORMAT_STRING)
                 .append(SEPARATOR)
-                .append(FORMAT_LEFT_ALIGN).append(getExecutionIdSize()).append(FORMAT_STRING)
+                .append(FORMAT_LEFT_ALIGN).append(getGoalSize()).append(FORMAT_STRING)
                 .append(SEPARATOR)
-                .append(FORMAT_LEFT_ALIGN).append(getGoalSize()).append(FORMAT_STRING);
+                .append(FORMAT_LEFT_ALIGN).append(getExecutionIdSize()).append(FORMAT_STRING);
         return builder.toString();
     }
 

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -85,30 +85,30 @@ Also, because executions are collected per phase, direct plugin-executions are s
 
 [INFO] --- buildplan-maven-plugin:${project.version}:list-plugin (default-cli) @ buildplan-maven-plugin ---
 [INFO] maven-deploy-plugin -------------------------------------------------------------------------
-[INFO]     + deploy                 | default-deploy                    | deploy
+[INFO]     + deploy                 | deploy                    | default-deploy
 [INFO] maven-source-plugin -------------------------------------------------------------------------
-[INFO]     + package                | attach-sources                    | jar-no-fork
+[INFO]     + package                | jar-no-fork               | attach-sources
 [INFO] license-maven-plugin ------------------------------------------------------------------------
-[INFO]     + verify                 | default                           | check
+[INFO]     + verify                 | check                     | default
 [INFO] maven-resources-plugin ----------------------------------------------------------------------
-[INFO]     + process-resources      | default-resources                 | resources
-[INFO]     + process-test-resources | default-testResources             | testResources
+[INFO]     + process-resources      | resources                 | default-resources
+[INFO]     + process-test-resources | testResources             | default-testResources
 [INFO] maven-plugin-plugin -------------------------------------------------------------------------
-[INFO]     + generate-sources       | help-goal                         | helpmojo
-[INFO]     + process-classes        | default-descriptor                | descriptor
-[INFO]     + process-classes        | mojo-descriptor                   | descriptor
-[INFO]     + package                | default-addPluginArtifactMetadata | addPluginArtifactMetadata
+[INFO]     + generate-sources       | helpmojo                  | help-goal
+[INFO]     + process-classes        | descriptor                | default-descriptor
+[INFO]     + process-classes        | descriptor                | mojo-descriptor
+[INFO]     + package                | addPluginArtifactMetadata | default-addPluginArtifactMetadata
 [INFO] maven-jar-plugin ----------------------------------------------------------------------------
-[INFO]     + package                | default-jar                       | jar
+[INFO]     + package                | jar                       | default-jar
 [INFO] animal-sniffer-maven-plugin -----------------------------------------------------------------
-[INFO]     + process-classes        | check-signature                   | check
+[INFO]     + process-classes        | check                     | check-signature
 [INFO] maven-surefire-plugin -----------------------------------------------------------------------
-[INFO]     + test                   | default-test                      | test
+[INFO]     + test                   | test                      | default-test
 [INFO] maven-compiler-plugin -----------------------------------------------------------------------
-[INFO]     + compile                | default-compile                   | compile
-[INFO]     + test-compile           | default-testCompile               | testCompile
+[INFO]     + compile                | compile                   | default-compile
+[INFO]     + test-compile           | testCompile               | default-testCompile
 [INFO] maven-install-plugin ------------------------------------------------------------------------
-[INFO]     + install                | default-install                   | install
+[INFO]     + install                | install                   | default-install
 ```
 It is possible to limit the list to a specific plugin:
 

--- a/src/test/java/org/codehaus/mojo/buildplan/ListPluginIT.java
+++ b/src/test/java/org/codehaus/mojo/buildplan/ListPluginIT.java
@@ -40,19 +40,19 @@ class ListPluginIT {
                 .plain()
                 .containsSequence(
                     "maven-resources-plugin ----------------------------------------------",
-                    "    + process-resources      | default-resources     | resources    ",
-                    "    + process-test-resources | default-testResources | testResources",
+                    "    + process-resources      | resources     | default-resources    ",
+                    "    + process-test-resources | testResources | default-testResources",
                     "maven-compiler-plugin -----------------------------------------------",
-                    "    + compile                | default-compile       | compile      ",
-                    "    + test-compile           | default-testCompile   | testCompile  ",
+                    "    + compile                | compile       | default-compile      ",
+                    "    + test-compile           | testCompile   | default-testCompile  ",
                     "maven-surefire-plugin -----------------------------------------------",
-                    "    + test                   | default-test          | test         ",
+                    "    + test                   | test          | default-test         ",
                     "maven-jar-plugin ----------------------------------------------------",
-                    "    + package                | default-jar           | jar          ",
+                    "    + package                | jar           | default-jar          ",
                     "maven-install-plugin ------------------------------------------------",
-                    "    + install                | default-install       | install      ",
+                    "    + install                | install       | default-install      ",
                     "maven-deploy-plugin -------------------------------------------------",
-                    "    + deploy                 | default-deploy        | deploy       "
+                    "    + deploy                 | deploy        | default-deploy       "
                 );
         }
 

--- a/src/test/java/org/codehaus/mojo/buildplan/display/ListPluginTableDescriptorTest.java
+++ b/src/test/java/org/codehaus/mojo/buildplan/display/ListPluginTableDescriptorTest.java
@@ -15,9 +15,9 @@
  */
 package org.codehaus.mojo.buildplan.display;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 class ListPluginTableDescriptorTest {
 
@@ -30,6 +30,6 @@ class ListPluginTableDescriptorTest {
 
         String result = descriptor.rowFormat();
 
-        assertThat(result).isEqualTo("    + %-1s | %-2s | %-3s");
+        assertThat(result).isEqualTo("    + %-1s | %-3s | %-2s");
     }
 }


### PR DESCRIPTION
It should be easier to read respecting the Maven hierarchical model (phase > plugin > goal > execution id)

Fixes #144