### PR TITLE
Fix tests by defining versions-maven-plugin version

### DIFF
--- a/src/test/resources-its/org/codehaus/mojo/buildplan/ListIT/MultiModuleProject/maven_project/pom.xml
+++ b/src/test/resources-its/org/codehaus/mojo/buildplan/ListIT/MultiModuleProject/maven_project/pom.xml
@@ -18,4 +18,16 @@
     <module>module-b</module>
   </modules>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>2.13.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>


### PR DESCRIPTION
The version was not set so that the test fails every time a new release of
versions-maven-plugin was published 😅.