### PR TITLE
Fix broken HTML table in report goal when using maven-site-plugin:4.0.0-M4

### DIFF
--- a/src/main/java/org/codehaus/mojo/buildplan/ReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/buildplan/ReportMojo.java
@@ -88,6 +88,7 @@ public class ReportMojo extends AbstractMavenReport {
         mainSink.header_();
 
         mainSink.table();
+        mainSink.tableRows(null, false);
 
         mainSink.tableRow();
         tableHead(mainSink, LIFECYCLE);
@@ -108,6 +109,7 @@ public class ReportMojo extends AbstractMavenReport {
             mainSink.tableRow_();
         }
 
+        mainSink.tableRows_();
         mainSink.table_();
 
         mainSink.body_();

--- a/src/test/java/org/codehaus/mojo/buildplan/ReportIT.java
+++ b/src/test/java/org/codehaus/mojo/buildplan/ReportIT.java
@@ -31,6 +31,82 @@ class ReportIT {
     @MavenTest
     @MavenGoal("site")
     @SystemProperty(value = "style.color", content = "always")
+    void generate_report_with_mvn_site_plugin_v4(MavenExecutionResult result) {
+        assertThat(result)
+                .isSuccessful()
+                .project()
+                .withFile("site/buildplan-report.html")
+                .content()
+                .satisfies(html -> {
+                    Document document = Jsoup.parse(html);
+                    assertThat(document.title())
+                            .isEqualTo("list-multimodule – Build Plan for list-multimodule 1.0-SNAPSHOT");
+                    assertThat(document.select("#titleContent").text())
+                            .isEqualTo("List plugin executions for org.codehaus.mojo.buildplan:list-multimodule");
+                    assertThat(document.select("table.table").outerHtml())
+                            .isEqualTo("<table class=\"table table-striped\">\n"
+                                    + " <tbody>\n"
+                                    + "  <tr class=\"a\">\n"
+                                    + "   <th>LIFECYCLE</th>\n"
+                                    + "   <th>PHASE</th>\n"
+                                    + "   <th>PLUGIN</th>\n"
+                                    + "   <th>GOAL</th>\n"
+                                    + "   <th>EXECUTION ID</th>\n"
+                                    + "  </tr>\n"
+                                    + "  <tr class=\"b\">\n"
+                                    + "   <td>default</td>\n"
+                                    + "   <td>install</td>\n"
+                                    + "   <td>maven-install-plugin</td>\n"
+                                    + "   <td>install</td>\n"
+                                    + "   <td>default-install</td>\n"
+                                    + "  </tr>\n"
+                                    + "  <tr class=\"a\">\n"
+                                    + "   <td>default</td>\n"
+                                    + "   <td>deploy</td>\n"
+                                    + "   <td>maven-deploy-plugin</td>\n"
+                                    + "   <td>deploy</td>\n"
+                                    + "   <td>default-deploy</td>\n"
+                                    + "  </tr>\n"
+                                    + " </tbody>\n"
+                                    + "</table>");
+                });
+
+        assertThat(result)
+                .project()
+                .withModule("module-a")
+                .withFile("site/buildplan-report.html")
+                .content()
+                .satisfies(html -> {
+                    Document document = Jsoup.parse(html);
+                    assertThat(document.title())
+                            .isEqualTo(
+                                    "list-multimodule-module-a – Build Plan for list-multimodule-module-a 1.0-SNAPSHOT");
+                    assertThat(document.select("#titleContent").text())
+                            .isEqualTo(
+                                    "List plugin executions for org.codehaus.mojo.buildplan:list-multimodule-module-a");
+                    assertThat(document.select("table.table").outerHtml()).isNotEmpty();
+                });
+
+        assertThat(result)
+                .project()
+                .withModule("module-b")
+                .withFile("site/buildplan-report.html")
+                .content()
+                .satisfies(html -> {
+                    Document document = Jsoup.parse(html);
+                    assertThat(document.title())
+                            .isEqualTo(
+                                    "list-multimodule-module-b – Build Plan for list-multimodule-module-b 1.0-SNAPSHOT");
+                    assertThat(document.select("#titleContent").text())
+                            .isEqualTo(
+                                    "List plugin executions for org.codehaus.mojo.buildplan:list-multimodule-module-b");
+                    assertThat(document.select("table.table").outerHtml()).isNotEmpty();
+                });
+    }
+
+    @MavenTest
+    @MavenGoal("site")
+    @SystemProperty(value = "style.color", content = "always")
     void generate_report_for_multimodule_project(MavenExecutionResult result) {
         assertThat(result)
                 .isSuccessful()

--- a/src/test/resources-its/org/codehaus/mojo/buildplan/ReportIT/generate_report_with_mvn_site_plugin_v4/module-a/pom.xml
+++ b/src/test/resources-its/org/codehaus/mojo/buildplan/ReportIT/generate_report_with_mvn_site_plugin_v4/module-a/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.codehaus.mojo.buildplan</groupId>
+        <artifactId>list-multimodule</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>list-multimodule-module-a</artifactId>
+
+</project>

--- a/src/test/resources-its/org/codehaus/mojo/buildplan/ReportIT/generate_report_with_mvn_site_plugin_v4/module-b/pom.xml
+++ b/src/test/resources-its/org/codehaus/mojo/buildplan/ReportIT/generate_report_with_mvn_site_plugin_v4/module-b/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.codehaus.mojo.buildplan</groupId>
+        <artifactId>list-multimodule</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>list-multimodule-module-b</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.19.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources-its/org/codehaus/mojo/buildplan/ReportIT/generate_report_with_mvn_site_plugin_v4/pom.xml
+++ b/src/test/resources-its/org/codehaus/mojo/buildplan/ReportIT/generate_report_with_mvn_site_plugin_v4/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.buildplan</groupId>
+  <artifactId>list-multimodule</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <description>
+    Test buildplan:report on multimodule project
+  </description>
+
+  <modules>
+    <module>module-a</module>
+    <module>module-b</module>
+  </modules>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+    </plugins>
+  </reporting>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>4.0.0-M4</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
Fixes #163 

First argument is for the columns text justification (`null` means left by default) and second argument is to draw borders but if set to true it will remove the style of the table.

https://maven.apache.org/doxia/doxia/doxia-sink-api/apidocs/org/apache/maven/doxia/sink/Sink.html#tableRows-int:A-boolean-

Let me know if you prefer constants or local variables to make this more explicit.

Before:
![image](https://user-images.githubusercontent.com/784863/212766775-ece001ee-0421-49b1-b661-f43913097381.png)

After:
![image](https://user-images.githubusercontent.com/784863/212766579-5aaa446e-1909-40ff-9804-3c2dc228a50a.png)
