### PR TITLE
Use the shared release-drafter config instead of a local copy

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,17 +1,4 @@
+_extends: .github:/.github/release-drafter.yml
+# buildplan-maven-plugin tags releases as v<version>, not as a bare version
 name-template: 'Release v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-categories:
-    - title: '🚀 Features'
-      labels:
-          - 'feature'
-    - title: '🐛 Bug Fixes'
-      labels:
-          - 'bug'
-    - title: '🧰 Maintenance'
-      label: 'chore'
-    - title: '⚙️ Dependencies'
-      label: 'dependencies'
-template: |
-    ## What’s Changed
-
-    $CHANGES


### PR DESCRIPTION
Replaces the standalone release-drafter config with `_extends` on the org config in `mojohaus/.github`, the same consolidation done in codehaus-plexus (plexus-utils, plexus-resources, plexus-classworlds).

The local copy predates the org config and carried only four categories — feature, bug, chore, dependencies — so PRs labelled `enhancement`, `documentation`, `build`, `test` or `maintenance` never appeared in the draft, and `exclude-labels` was absent entirely. The org config covers all of them.

`name-template` and `tag-template` stay as overrides: this repo tags `v2.2.2`, whereas the org default resolves to a bare version.

*This change was created with AI assistance.*
