### PR TITLE
Call the shared test-results workflow

### DIFF
--- a/.github/workflows/tests-result.yml
+++ b/.github/workflows/tests-result.yml
@@ -5,41 +5,13 @@ on:
     workflows: ["CI"]
     types:
       - completed
+
 permissions: {}
 
 jobs:
   test-results:
-    name: Test Results
-    runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion != 'skipped'
-
     permissions:
       checks: write
-      # needed unless run with comment_mode: off
       pull-requests: write
-      # required by download step to access artifacts API
       actions: read
-
-    steps:
-      - name: Download and Extract Artifacts
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: |
-          mkdir -p artifacts && cd artifacts
-
-          artifacts_url=${{ github.event.workflow_run.artifacts_url }}
-
-          gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
-          do
-          IFS=$'\t' read name url <<< "$artifact"
-          gh api $url > "$name.zip"
-          unzip -d "$name" "$name.zip"
-          done
-
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        with:
-          commit: ${{ github.event.workflow_run.head_sha }}
-          event_file: artifacts/Event File/event.json
-          event_name: ${{ github.event.workflow_run.event }}
-          junit_files: "artifacts/**/TEST*.xml"
+    uses: mojohaus/.github/.github/workflows/test-results.yml@master


### PR DESCRIPTION
Replaces the local JUnit publishing recipe with a call to `mojohaus/.github/.github/workflows/test-results.yml`, so the `EnricoMi/publish-unit-test-result-action` version and the permission set are maintained once for the org rather than per repo. `maven.yml` is untouched — it already uploads the two artifacts the shared workflow expects.

Draft until mojohaus/.github#3 merges; the `uses:` reference does not resolve before then.

*This change was created with AI assistance.*