### PR TITLE
Pin the lifecycle plugin versions the build-plan tests assert

### DIFF
--- a/src/test/resources-its/org/codehaus/mojo/buildplan/ListIT/MultiModuleProject/maven_project/pom.xml
+++ b/src/test/resources-its/org/codehaus/mojo/buildplan/ListIT/MultiModuleProject/maven_project/pom.xml
@@ -26,6 +26,35 @@
           <artifactId>versions-maven-plugin</artifactId>
           <version>2.13.0</version>
         </plugin>
+        <!-- Pinned so the expected build plan does not shift with the Maven under test. -->
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>2.5</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>2.6</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.12.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.7</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/src/test/resources-its/org/codehaus/mojo/buildplan/ListIT/SimpleProject/maven_project/pom.xml
+++ b/src/test/resources-its/org/codehaus/mojo/buildplan/ListIT/SimpleProject/maven_project/pom.xml
@@ -12,4 +12,40 @@
     Test buildplan:list
   </description>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <!-- Pinned so the expected build plan does not shift with the Maven under test. -->
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>2.5</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>2.6</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.12.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.7</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>


### PR DESCRIPTION
`ListIT` asserts the printed build plan line by line, versions and column padding included, and the fixtures took their plugin versions from the Maven super POM. Those expectations were therefore Maven 3.8.8's default bindings, and #295 — which moves the wrapper to 3.9.16 — changes all of them:

| plugin | 3.8.8 | 3.9.16 |
|---|---|---|
| maven-resources-plugin | 2.6 | 3.4.0 |
| maven-compiler-plugin | 3.1 | 3.15.0 |
| maven-surefire-plugin | 2.12.4 | 3.5.4 |
| maven-jar-plugin | 2.4 | 3.5.0 |
| maven-install-plugin | 2.4 | 3.1.4 |
| maven-deploy-plugin | 2.7 | 3.1.4 |

The longer versions also widen the VERSION column, so all 7 cases fail, not just the version strings.

Pinning those versions in the two `ListIT` fixtures decouples the assertions from whichever Maven runs them. No test expectation changes — the fixtures simply now state what the tests already assumed. The multi-module fixture already pinned `versions-maven-plugin` this way.

Verified with `mvn clean verify` (full IT suite, `target/maven-it` removed first — itf caches the extracted project and will otherwise reuse a stale pom):

| wrapper | before | after |
|---|---|---|
| 3.8.8 | pass | pass |
| 3.9.16 | 7 failures | pass |

This PR leaves the wrapper on 3.8.8. Rebase #295 on top and it goes green.

*This change was created with AI assistance.*